### PR TITLE
Tighten file path sanitization and confinement

### DIFF
--- a/acp/core/uploads/functions.php
+++ b/acp/core/uploads/functions.php
@@ -14,6 +14,13 @@ function delete_folder($dir) {
 
     $dir = se_filter_filepath($dir);
 
+    // confine deletion to a subfolder of the public directory; reject traversal
+    // attempts and refuse to operate on the public root itself
+    $resolved = se_resolve_within(SE_PUBLIC, $dir);
+    if ($resolved === false || $resolved === rtrim(SE_PUBLIC, '/')) {
+        return false;
+    }
+
     $delete_folder = SE_PUBLIC.'/'.$dir;
     $files = array_diff(scandir($delete_folder), array('.','..'));
     foreach ($files as $file) {

--- a/app/functions/functions.sanitizer.php
+++ b/app/functions/functions.sanitizer.php
@@ -23,12 +23,78 @@ function clean_filename($str) {
 	return $str; 
 }
 
+/**
+ * Filter a file path on the character level (whitelist based).
+ *
+ * Keeps slashes and the relative ".." that the upload/media paths rely on,
+ * but strips null bytes, control characters, stream-wrapper colons and any
+ * character outside the safe set. This is a character filter only - use
+ * se_resolve_within() for actual directory confinement.
+ *
+ * @param mixed $str
+ * @return string
+ */
 function se_filter_filepath($str) {
+	if (!is_string($str)) {
+		return '';
+	}
+
 	$str = strip_tags($str);
-	$remove_chars = array('<','>','\\','=','@','(',')',' ',',','%','');
+
+	// remove null bytes and control characters
+	$str = preg_replace('/[\x00-\x1F\x7F]/u', '', $str);
+
+	// replace whitespace with underscores
 	$str = preg_replace('/\s/s', '_', $str);
-	$str = str_replace($remove_chars, "", $str);
-	return $str; 
+
+	// normalise backslashes to forward slashes
+	$str = str_replace('\\', '/', $str);
+
+	// whitelist: only a-z A-Z 0-9 _ . - /
+	$str = preg_replace('#[^A-Za-z0-9_./-]#', '', $str);
+
+	// collapse runs of dots and slashes (e.g. "....//" -> "..//" -> "../")
+	$str = preg_replace('/\.{2,}/', '..', $str);
+	$str = preg_replace('#/{2,}#', '/', $str);
+
+	return $str;
+}
+
+/**
+ * Resolve $path relative to $base and guarantee the result stays inside $base.
+ *
+ * Resolves "." and ".." segments manually so it also works for paths that do
+ * not exist on disk yet (unlike realpath()). Returns the confined absolute
+ * path on success or false if the path would escape $base (traversal attempt).
+ *
+ * @param string $base absolute base directory (no trailing slash required)
+ * @param string $path untrusted relative path
+ * @return string|false
+ */
+function se_resolve_within(string $base, string $path) {
+	$base = rtrim($base, '/');
+	$candidate = $base . '/' . ltrim(se_filter_filepath($path), '/');
+
+	// resolve "." and ".." segments without touching the filesystem
+	$parts = array();
+	foreach (explode('/', $candidate) as $seg) {
+		if ($seg === '' || $seg === '.') {
+			continue;
+		}
+		if ($seg === '..') {
+			array_pop($parts);
+			continue;
+		}
+		$parts[] = $seg;
+	}
+	$resolved = '/' . implode('/', $parts);
+
+	// reject anything that resolved outside of $base
+	if (!str_starts_with($resolved . '/', $base . '/')) {
+		return false;
+	}
+
+	return $resolved;
 }
 
 function se_return_clean_value($string) {


### PR DESCRIPTION
Improve file path sanitization and add directory traversal protection

- Introduced `se_filter_filepath` for stricter file path sanitization, replacing character removal with a whitelist-based approach.
- Added `se_resolve_within` to ensure paths remain confined to specified base directories.
- Updated file deletion logic in `uploads/functions.php` to leverage new traversal safeguards, preventing unauthorized access to the public root.

see issue: https://github.com/SwiftyEdit/SwiftyEdit/issues/338