### PR TITLE
Migrate PayPal integration to new Server SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,18 +20,18 @@
     "vendor-dir": "vendor"
   },
   "require": {
+    "ext-pdo": "*",
     "catfan/medoo": "^2.1.12",
     "erusev/parsedown": "1.7.4",
     "erusev/parsedown-extra": "^0.8.1",
-    "phpmailer/phpmailer": "^v6.10.0",
-    "smarty/smarty": "^v5.8.2",
+    "ezyang/htmlpurifier": "^v4.18.0",
+    "guzzlehttp/guzzle": "^7.12.3",
     "league/iso3166": "^4.4.0",
     "mustangostang/spyc": "^0.6.3",
-    "paypal/paypal-checkout-sdk": "1.0.2",
-    "guzzlehttp/guzzle": "^7.12.3",
-    "ezyang/htmlpurifier": "^v4.18.0",
-    "twig/twig": "^3.0",
-    "ext-pdo": "*"
+    "paypal/paypal-server-sdk": "^2.3",
+    "phpmailer/phpmailer": "^v6.10.0",
+    "smarty/smarty": "^v5.8.2",
+    "twig/twig": "^3.0"
   },
   "scripts": {
     "buildclean": "rm -rf dist && rm -f ./dist/*.zip",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,225 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "874ce887f8f4e4668a2fe71f591533a3",
+    "content-hash": "6a6d62946d8e66371a362c867b7f2cb5",
     "packages": [
+        {
+            "name": "apimatic/core",
+            "version": "0.3.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/apimatic/core-lib-php.git",
+                "reference": "a48a583f686ee3786432b976c795a2817ec095b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/apimatic/core-lib-php/zipball/a48a583f686ee3786432b976c795a2817ec095b3",
+                "reference": "a48a583f686ee3786432b976c795a2817ec095b3",
+                "shasum": ""
+            },
+            "require": {
+                "apimatic/core-interfaces": "~0.1.5",
+                "apimatic/jsonmapper": "^3.1.1",
+                "ext-curl": "*",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "php": "^7.2 || ^8.0",
+                "php-jsonpointer/php-jsonpointer": "^3.0.2",
+                "psr/log": "^1.1.4 || ^2.0.0 || ^3.0.0",
+                "symfony/http-foundation": "^5.4 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phan/phan": "5.4.5",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Core\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Core logic and the utilities for the Apimatic's PHP SDK",
+            "homepage": "https://github.com/apimatic/core-lib-php",
+            "keywords": [
+                "apimatic",
+                "core",
+                "corelib",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/apimatic/core-lib-php/issues",
+                "source": "https://github.com/apimatic/core-lib-php/tree/0.3.17"
+            },
+            "time": "2026-01-27T05:14:10+00:00"
+        },
+        {
+            "name": "apimatic/core-interfaces",
+            "version": "0.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/apimatic/core-interfaces-php.git",
+                "reference": "b4f1bffc8be79584836f70af33c65e097eec155c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/apimatic/core-interfaces-php/zipball/b4f1bffc8be79584836f70af33c65e097eec155c",
+                "reference": "b4f1bffc8be79584836f70af33c65e097eec155c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CoreInterfaces\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Definition of the behavior of apimatic/core, apimatic/unirest-php and Apimatic's PHP SDK",
+            "homepage": "https://github.com/apimatic/core-interfaces-php",
+            "keywords": [
+                "apimatic",
+                "core",
+                "corelib",
+                "interface",
+                "php",
+                "unirest"
+            ],
+            "support": {
+                "issues": "https://github.com/apimatic/core-interfaces-php/issues",
+                "source": "https://github.com/apimatic/core-interfaces-php/tree/0.1.5"
+            },
+            "time": "2024-05-09T06:32:07+00:00"
+        },
+        {
+            "name": "apimatic/jsonmapper",
+            "version": "3.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/apimatic/jsonmapper.git",
+                "reference": "61e45f6021e4a4e07497be596b4787c3c6b39bea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/apimatic/jsonmapper/zipball/61e45f6021e4a4e07497be596b4787c3c6b39bea",
+                "reference": "61e45f6021e4a4e07497be596b4787c3c6b39bea",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^5.6 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+                "squizlabs/php_codesniffer": "^3.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "apimatic\\jsonmapper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "christian.weiske@netresearch.de",
+                    "homepage": "http://www.netresearch.de/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Mehdi Jaffery",
+                    "email": "mehdi.jaffery@apimatic.io",
+                    "homepage": "http://apimatic.io/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "support": {
+                "email": "mehdi.jaffery@apimatic.io",
+                "issues": "https://github.com/apimatic/jsonmapper/issues",
+                "source": "https://github.com/apimatic/jsonmapper/tree/3.1.7"
+            },
+            "time": "2025-11-06T14:43:04+00:00"
+        },
+        {
+            "name": "apimatic/unirest-php",
+            "version": "4.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/apimatic/unirest-php.git",
+                "reference": "bdfd5f27c105772682c88ed671683f1bd93f4a3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/apimatic/unirest-php/zipball/bdfd5f27c105772682c88ed671683f1bd93f4a3c",
+                "reference": "bdfd5f27c105772682c88ed671683f1bd93f4a3c",
+                "shasum": ""
+            },
+            "require": {
+                "apimatic/core-interfaces": "^0.1.0",
+                "ext-curl": "*",
+                "ext-json": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "phan/phan": "5.4.2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Unirest\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mashape",
+                    "email": "opensource@mashape.com",
+                    "homepage": "https://www.mashape.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "APIMATIC",
+                    "email": "opensource@apimatic.io",
+                    "homepage": "https://www.apimatic.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Unirest PHP",
+            "homepage": "https://github.com/apimatic/unirest-php",
+            "keywords": [
+                "client",
+                "curl",
+                "http",
+                "https",
+                "rest"
+            ],
+            "support": {
+                "email": "opensource@apimatic.io",
+                "issues": "https://github.com/apimatic/unirest-php/issues",
+                "source": "https://github.com/apimatic/unirest-php/tree/4.0.7"
+            },
+            "time": "2025-06-17T09:09:48+00:00"
+        },
         {
             "name": "catfan/medoo",
             "version": "v2.4.0",
@@ -697,83 +914,79 @@
             "time": "2019-09-10T13:16:29+00:00"
         },
         {
-            "name": "paypal/paypal-checkout-sdk",
-            "version": "1.0.2",
+            "name": "paypal/paypal-server-sdk",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/paypal/Checkout-PHP-SDK.git",
-                "reference": "19992ce7051ff9e47e643f28abb8cc1b3e5f1812"
+                "url": "https://github.com/paypal/PayPal-PHP-Server-SDK.git",
+                "reference": "c54fefd059802b4fde7182d708b4d2dc99f9d2e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paypal/Checkout-PHP-SDK/zipball/19992ce7051ff9e47e643f28abb8cc1b3e5f1812",
-                "reference": "19992ce7051ff9e47e643f28abb8cc1b3e5f1812",
+                "url": "https://api.github.com/repos/paypal/PayPal-PHP-Server-SDK/zipball/c54fefd059802b4fde7182d708b4d2dc99f9d2e5",
+                "reference": "c54fefd059802b4fde7182d708b4d2dc99f9d2e5",
                 "shasum": ""
             },
             "require": {
-                "paypal/paypalhttp": "1.0.1"
+                "apimatic/core": "~0.3.17",
+                "apimatic/core-interfaces": "~0.1.5",
+                "apimatic/unirest-php": "^4.0.6",
+                "ext-curl": "*",
+                "ext-json": "*",
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7"
+                "phan/phan": "5.4.5",
+                "squizlabs/php_codesniffer": "^3.5"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Sample\\": "samples/",
-                    "PayPalCheckoutSdk\\": "lib/PayPalCheckoutSdk"
+                    "PaypalServerSdkLib\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "https://github.com/paypal/Checkout-PHP-SDK/blob/master/LICENSE"
+                "MIT"
             ],
-            "authors": [
-                {
-                    "name": "PayPal",
-                    "homepage": "https://github.com/paypal/Checkout-PHP-SDK/contributors"
-                }
-            ],
-            "description": "PayPal's PHP SDK for Checkout REST APIs",
-            "homepage": "http://github.com/paypal/Checkout-PHP-SDK/",
-            "keywords": [
-                "checkout",
-                "orders",
-                "payments",
-                "paypal",
-                "rest",
-                "sdk"
-            ],
+            "description": "PayPal's SDK for interacting with the REST APIs",
+            "homepage": "https://github.com/paypal/PayPal-PHP-Server-SDK",
             "support": {
-                "source": "https://github.com/paypal/Checkout-PHP-SDK/tree/1.0.2"
+                "issues": "https://github.com/paypal/PayPal-PHP-Server-SDK/issues",
+                "source": "https://github.com/paypal/PayPal-PHP-Server-SDK/tree/2.3.0"
             },
-            "abandoned": "paypal/paypal-server-sdk",
-            "time": "2021-09-21T20:57:38+00:00"
+            "time": "2026-06-05T21:28:21+00:00"
         },
         {
-            "name": "paypal/paypalhttp",
-            "version": "1.0.1",
+            "name": "php-jsonpointer/php-jsonpointer",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/paypal/paypalhttp_php.git",
-                "reference": "7b09c89c80828e842c79230e7f156b61fbb68d25"
+                "url": "https://github.com/raphaelstolt/php-jsonpointer.git",
+                "reference": "4428f86c6f23846e9faa5a420c4ef14e485b3afb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paypal/paypalhttp_php/zipball/7b09c89c80828e842c79230e7f156b61fbb68d25",
-                "reference": "7b09c89c80828e842c79230e7f156b61fbb68d25",
+                "url": "https://api.github.com/repos/raphaelstolt/php-jsonpointer/zipball/4428f86c6f23846e9faa5a420c4ef14e485b3afb",
+                "reference": "4428f86c6f23846e9faa5a420c4ef14e485b3afb",
                 "shasum": ""
             },
             "require": {
-                "ext-curl": "*"
+                "php": ">=5.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7",
-                "wiremock-php/wiremock-php": "1.43.2"
+                "friendsofphp/php-cs-fixer": "^1.11",
+                "phpunit/phpunit": "4.6.*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
-                "psr-4": {
-                    "PayPalHttp\\": "lib/PayPalHttp"
+                "psr-0": {
+                    "Rs\\Json": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -782,16 +995,23 @@
             ],
             "authors": [
                 {
-                    "name": "PayPal",
-                    "homepage": "https://github.com/paypal/paypalhttp_php/contributors"
+                    "name": "Raphael Stolt",
+                    "email": "raphael.stolt@gmail.com",
+                    "homepage": "http://raphaelstolt.blogspot.com/"
                 }
             ],
+            "description": "Implementation of JSON Pointer (http://tools.ietf.org/html/rfc6901)",
+            "homepage": "https://github.com/raphaelstolt/php-jsonpointer",
+            "keywords": [
+                "json",
+                "json pointer",
+                "json traversal"
+            ],
             "support": {
-                "issues": "https://github.com/paypal/paypalhttp_php/issues",
-                "source": "https://github.com/paypal/paypalhttp_php/tree/1.0.1"
+                "issues": "https://github.com/raphaelstolt/php-jsonpointer/issues",
+                "source": "https://github.com/raphaelstolt/php-jsonpointer/tree/master"
             },
-            "abandoned": true,
-            "time": "2021-09-14T21:35:26+00:00"
+            "time": "2016-08-29T08:51:01+00:00"
         },
         {
             "name": "phpmailer/phpmailer",
@@ -1035,6 +1255,56 @@
             "time": "2023-04-04T09:54:51+00:00"
         },
         {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
             "name": "ralouphie/getallheaders",
             "version": "3.0.3",
             "source": {
@@ -1224,6 +1494,88 @@
                 }
             ],
             "time": "2026-04-13T15:52:40+00:00"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v7.4.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "06db5ae1552177bf8572f8908839f12e3c06aed3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/06db5ae1552177bf8572f8908839f12e3c06aed3",
+                "reference": "06db5ae1552177bf8572f8908839f12e3c06aed3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "^1.1"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6",
+                "symfony/cache": "<6.4.12|>=7.0,<7.1.5"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^3.6|^4",
+                "predis/predis": "^1.1|^2.0",
+                "symfony/cache": "^6.4.12|^7.1.5|^8.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^6.4|^7.0|^8.0",
+                "symfony/rate-limiter": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpFoundation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Defines an object-oriented layer for the HTTP specification",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.14"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-11T07:31:44+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/plugins/se_paypal-pay/aftersale.php
+++ b/plugins/se_paypal-pay/aftersale.php
@@ -9,12 +9,10 @@
  * @var array $lang
  */
 
-use PayPalCheckoutSdk\Core\PayPalHttpClient;
-use PayPalCheckoutSdk\Core\ProductionEnvironment;
-use PayPalCheckoutSdk\Core\SandboxEnvironment;
-use PayPalCheckoutSdk\Orders\OrdersCreateRequest;
-
-
+use PaypalServerSdkLib\Authentication\ClientCredentialsAuthCredentialsBuilder;
+use PaypalServerSdkLib\Environment;
+use PaypalServerSdkLib\Exceptions\ApiException;
+use PaypalServerSdkLib\PaypalServerSdkClientBuilder;
 
 require_once SE_ROOT.'plugins/se_paypal-pay/global/functions.php';
 
@@ -30,51 +28,57 @@ if($paypal_settings['paypal_mode'] == 'live') {
     $clientSecret = $paypal_settings['paypal_client_secret'];
     $paypal_return_url = $paypal_settings['paypal_return_url'];
     $paypal_cancel_url = $paypal_settings['paypal_cancel_url'];
-    $environment = new ProductionEnvironment($clientId, $clientSecret);
+    $environment = Environment::PRODUCTION;
 } else {
     $clientId = $paypal_settings['paypal_sb_client_id'];
     $clientSecret = $paypal_settings['paypal_sb_client_secret'];
     $paypal_return_url = $paypal_settings['paypal_sb_return_url'];
     $paypal_cancel_url = $paypal_settings['paypal_sb_cancel_url'];
-    $environment = new SandboxEnvironment($clientId, $clientSecret);
+    $environment = Environment::SANDBOX;
 }
 
-$client = new PayPalHttpClient($environment);
+$client = PaypalServerSdkClientBuilder::init()
+    ->clientCredentialsAuthCredentials(
+        ClientCredentialsAuthCredentialsBuilder::init($clientId, $clientSecret)
+    )
+    ->environment($environment)
+    ->build();
 
-
-$cart_test = print_r($order_data, true);
 $reference_id = $order_data['order_nbr'];
 
-$request = new OrdersCreateRequest();
-$request->prefer('return=representation');
-$request->body = [
-    "intent" => "CAPTURE",
-    "purchase_units" => [[
-        "reference_id" => $reference_id,
-        "amount" => [
-            "currency_code" => $order_currency,
-            "value" => $order_value
-        ]
-    ]],
-    "application_context" => [
-        "return_url" => $paypal_return_url,
-        "cancel_url" => $paypal_cancel_url,
-        "brand_name" => $se_settings['pagename'],
-        "landing_page" => "LOGIN",  // oder "BILLING"
-        "user_action" => "PAY_NOW"
-    ]
-];
+$response_string = '';
 
 try {
-    $response = $client->execute($request);
-} catch (HttpException $ex) {
-    $response_string = "ERROR: " . $ex->getMessage();
-}
+    $response = $client->getOrdersController()->createOrder([
+        'body' => [
+            "intent" => "CAPTURE",
+            "purchase_units" => [[
+                "reference_id" => $reference_id,
+                "amount" => [
+                    "currency_code" => $order_currency,
+                    "value" => $order_value
+                ]
+            ]],
+            "application_context" => [
+                "return_url" => $paypal_return_url,
+                "cancel_url" => $paypal_cancel_url,
+                "brand_name" => $se_settings['pagename'],
+                "landing_page" => "LOGIN",  // or "BILLING"
+                "user_action" => "PAY_NOW"
+            ]
+        ],
+        'prefer' => 'return=representation'
+    ]);
 
-foreach ($response->result->links as $link) {
-    if ($link->rel === 'approve') {
-        $response_string = '<p><a class="btn btn-info w-100" href="' . $link->href . '">'.$lang['btn_pay_with_paypal'].'</a></p>';
+    $order = $response->getResult();
+
+    foreach ($order->getLinks() as $link) {
+        if ($link->getRel() === 'approve') {
+            $response_string = '<p><a class="btn btn-info w-100" href="' . $link->getHref() . '">'.$lang['btn_pay_with_paypal'].'</a></p>';
+        }
     }
+} catch (ApiException $ex) {
+    $response_string = "ERROR: " . $ex->getMessage();
 }
 
 $cart_alert = $response_string;

--- a/plugins/se_paypal-pay/aftersale_listing.php
+++ b/plugins/se_paypal-pay/aftersale_listing.php
@@ -10,10 +10,10 @@
  * @var array $lang
  */
 
-use PayPalCheckoutSdk\Core\PayPalHttpClient;
-use PayPalCheckoutSdk\Core\ProductionEnvironment;
-use PayPalCheckoutSdk\Core\SandboxEnvironment;
-use PayPalCheckoutSdk\Orders\OrdersCreateRequest;
+use PaypalServerSdkLib\Authentication\ClientCredentialsAuthCredentialsBuilder;
+use PaypalServerSdkLib\Environment;
+use PaypalServerSdkLib\Exceptions\ApiException;
+use PaypalServerSdkLib\PaypalServerSdkClientBuilder;
 
 require_once SE_ROOT.'plugins/se_paypal-pay/global/functions.php';
 $paypal_settings = pp_get_settings();
@@ -23,16 +23,21 @@ if($paypal_settings['paypal_mode'] == 'live') {
     $clientSecret = $paypal_settings['paypal_client_secret'];
     $paypal_return_url = $paypal_settings['paypal_return_url'];
     $paypal_cancel_url = $paypal_settings['paypal_cancel_url'];
-    $environment = new ProductionEnvironment($clientId, $clientSecret);
+    $environment = Environment::PRODUCTION;
 } else {
     $clientId = $paypal_settings['paypal_sb_client_id'];
     $clientSecret = $paypal_settings['paypal_sb_client_secret'];
     $paypal_return_url = $paypal_settings['paypal_sb_return_url'];
     $paypal_cancel_url = $paypal_settings['paypal_sb_cancel_url'];
-    $environment = new SandboxEnvironment($clientId, $clientSecret);
+    $environment = Environment::SANDBOX;
 }
 
-$client = new PayPalHttpClient($environment);
+$client = PaypalServerSdkClientBuilder::init()
+    ->clientCredentialsAuthCredentials(
+        ClientCredentialsAuthCredentialsBuilder::init($clientId, $clientSecret)
+    )
+    ->environment($environment)
+    ->build();
 
 $reference_id = $order_data['order_nbr'];
 
@@ -41,36 +46,39 @@ $order_value = str_replace(',', '.', $order_value);
 $order_value = round($order_value,2);
 $order_currency = $se_settings['posts_products_default_currency'];
 
-$request = new OrdersCreateRequest();
-$request->prefer('return=representation');
-$request->body = [
-    "intent" => "CAPTURE",
-    "purchase_units" => [[
-        "reference_id" => $reference_id,
-        "amount" => [
-            "currency_code" => $order_currency,
-            "value" => $order_value
-        ]
-    ]],
-    "application_context" => [
-        "return_url" => $paypal_return_url,
-        "cancel_url" => $paypal_cancel_url,
-        "brand_name" => $se_settings['pagename'],
-        "landing_page" => "LOGIN",
-        "user_action" => "PAY_NOW"
-    ]
-];
+$response_str = '';
 
 try {
-    $response = $client->execute($request);
-} catch (HttpException $ex) {
-    $response_str = "ERROR: " . $ex->getMessage();
-}
+    $response = $client->getOrdersController()->createOrder([
+        'body' => [
+            "intent" => "CAPTURE",
+            "purchase_units" => [[
+                "reference_id" => $reference_id,
+                "amount" => [
+                    "currency_code" => $order_currency,
+                    "value" => $order_value
+                ]
+            ]],
+            "application_context" => [
+                "return_url" => $paypal_return_url,
+                "cancel_url" => $paypal_cancel_url,
+                "brand_name" => $se_settings['pagename'],
+                "landing_page" => "LOGIN",
+                "user_action" => "PAY_NOW"
+            ]
+        ],
+        'prefer' => 'return=representation'
+    ]);
 
-foreach ($response->result->links as $link) {
-    if ($link->rel === 'approve') {
-        $response_str = '<p><a class="btn btn-info w-100" href="' . $link->href . '">'.$lang['btn_pay_with_paypal'].'</a></p>';
+    $order = $response->getResult();
+
+    foreach ($order->getLinks() as $link) {
+        if ($link->getRel() === 'approve') {
+            $response_str = '<p><a class="btn btn-info w-100" href="' . $link->getHref() . '">'.$lang['btn_pay_with_paypal'].'</a></p>';
+        }
     }
+} catch (ApiException $ex) {
+    $response_str = "ERROR: " . $ex->getMessage();
 }
 
 $pm_plugin_str = $response_str;

--- a/plugins/se_paypal-pay/backend/reader.php
+++ b/plugins/se_paypal-pay/backend/reader.php
@@ -1,9 +1,9 @@
 <?php
 
-use PayPalCheckoutSdk\Core\PayPalHttpClient;
-use PayPalCheckoutSdk\Core\SandboxEnvironment;
-use PayPalCheckoutSdk\Orders\OrdersCreateRequest;
-use PayPalCheckoutSdk\Core\ProductionEnvironment;
+use PaypalServerSdkLib\Authentication\ClientCredentialsAuthCredentialsBuilder;
+use PaypalServerSdkLib\Environment;
+use PaypalServerSdkLib\Exceptions\ApiException;
+use PaypalServerSdkLib\PaypalServerSdkClientBuilder;
 
 
 require_once SE_ROOT.'plugins/se_paypal-pay/global/functions.php';
@@ -48,15 +48,20 @@ if($_GET['show'] == 'paypal_tests') {
     if($paypal_settings['paypal_mode'] == 'live') {
         $clientId = $paypal_settings['paypal_client_id'];
         $clientSecret = $paypal_settings['paypal_client_secret'];
-        $environment = new ProductionEnvironment($clientId, $clientSecret);
+        $environment = Environment::PRODUCTION;
     } else {
         $clientId = $paypal_settings['paypal_sb_client_id'];
         $clientSecret = $paypal_settings['paypal_sb_client_secret'];
-        $environment = new SandboxEnvironment($clientId, $clientSecret);
+        $environment = Environment::SANDBOX;
     }
 
 
-    $client = new PayPalHttpClient($environment);
+    $client = PaypalServerSdkClientBuilder::init()
+        ->clientCredentialsAuthCredentials(
+            ClientCredentialsAuthCredentialsBuilder::init($clientId, $clientSecret)
+        )
+        ->environment($environment)
+        ->build();
 
     echo '<form hx-post="/admin-xhr/addons/plugin/se_paypal-pay/read/?show=paypal_tests" method="post">';
 
@@ -86,31 +91,33 @@ if($_GET['show'] == 'paypal_tests') {
             "order_currency" => "EUR"
         ];
 
-        $request = new OrdersCreateRequest();
-        $request->prefer('return=representation');
-        $request->body = [
-            "intent" => "CAPTURE",
-            "purchase_units" => [[
-                "amount" => [
-                    "currency_code" => $demo_order['order_currency'],
-                    "value" => $demo_order['order_value']
-                ]
-            ]]
-        ];
-
         try {
-            $response = $client->execute($request);
-            echo '<div class="alert alert-success">';
-            echo "Order ID: " . $response->result->id;
-            echo '</div>';
-        } catch (HttpException $ex) {
-            echo "ERROR: " . $ex->getMessage();
-        }
+            $response = $client->getOrdersController()->createOrder([
+                'body' => [
+                    "intent" => "CAPTURE",
+                    "purchase_units" => [[
+                        "amount" => [
+                            "currency_code" => $demo_order['order_currency'],
+                            "value" => $demo_order['order_value']
+                        ]
+                    ]]
+                ],
+                'prefer' => 'return=representation'
+            ]);
 
-        foreach ($response->result->links as $link) {
-            if ($link->rel === 'approve') {
-                echo '<p><a class="btn btn-info w-100" href="' . $link->href . '">Pay with PayPal</a></p>';
+            $order = $response->getResult();
+
+            echo '<div class="alert alert-success">';
+            echo "Order ID: " . $order->getId();
+            echo '</div>';
+
+            foreach ($order->getLinks() as $link) {
+                if ($link->getRel() === 'approve') {
+                    echo '<p><a class="btn btn-info w-100" href="' . $link->getHref() . '">Pay with PayPal</a></p>';
+                }
             }
+        } catch (ApiException $ex) {
+            echo "ERROR: " . $ex->getMessage();
         }
 
     }

--- a/plugins/se_paypal-pay/backend/writer.php
+++ b/plugins/se_paypal-pay/backend/writer.php
@@ -19,7 +19,7 @@ if(isset($_POST['save_paypal_prefs'])) {
 
     $paypal_mode = $_POST['paypal_mode'] == 'live' ? 'live' : 'sandbox';
 
-    $pm_prefs_content = str_replace("{addon_name}","se_cash-pay",$pm_prefs_content_file);
+    $pm_prefs_content = str_replace("{addon_name}","se_paypal-pay",$pm_prefs_content_file);
     $pm_prefs_content = str_replace("{addon_additional_costs}","$paypal_additional_costs",$pm_prefs_content);
     $pm_prefs_content = str_replace("{addon_snippet_cart}","$paypal_snippet",$pm_prefs_content);
 

--- a/plugins/se_paypal-pay/global/index.php
+++ b/plugins/se_paypal-pay/global/index.php
@@ -5,11 +5,10 @@
  * check if payment was successful
  */
 
-use PayPalCheckoutSdk\Core\PayPalHttpClient;
-use PayPalCheckoutSdk\Core\ProductionEnvironment;
-use PayPalCheckoutSdk\Core\SandboxEnvironment;
-use PayPalCheckoutSdk\Orders\OrdersCaptureRequest;
-use PayPalHttp\HttpException;
+use PaypalServerSdkLib\Authentication\ClientCredentialsAuthCredentialsBuilder;
+use PaypalServerSdkLib\Environment;
+use PaypalServerSdkLib\Exceptions\ApiException;
+use PaypalServerSdkLib\PaypalServerSdkClientBuilder;
 
 require_once SE_ROOT.'plugins/se_paypal-pay/global/functions.php';
 
@@ -19,18 +18,23 @@ if($paypal_settings['paypal_mode'] == 'live') {
     $clientId = $paypal_settings['paypal_client_id'];
     $clientSecret = $paypal_settings['paypal_client_secret'];
     $paypal_url = parse_url($paypal_settings['paypal_return_url']);
-    $environment = new ProductionEnvironment($clientId, $clientSecret);
+    $environment = Environment::PRODUCTION;
 } else {
     $clientId = $paypal_settings['paypal_sb_client_id'];
     $clientSecret = $paypal_settings['paypal_sb_client_secret'];
     $paypal_url = parse_url($paypal_settings['paypal_sb_return_url']);
-    $environment = new SandboxEnvironment($clientId, $clientSecret);
+    $environment = Environment::SANDBOX;
 }
 
 $paypal_url_str = substr($paypal_url['path'],1);
 if(isset($_GET['token']) && $_REQUEST['query'] == $paypal_url_str){
 
-    $client = new PayPalHttpClient($environment);
+    $client = PaypalServerSdkClientBuilder::init()
+        ->clientCredentialsAuthCredentials(
+            ClientCredentialsAuthCredentialsBuilder::init($clientId, $clientSecret)
+        )
+        ->environment($environment)
+        ->build();
 
     $orderId = $_GET['token'] ?? null;
     if (!$orderId) {
@@ -40,16 +44,19 @@ if(isset($_GET['token']) && $_REQUEST['query'] == $paypal_url_str){
     $return_str = '';
 
     try {
-        // get data from PayPal
-        $request = new OrdersCaptureRequest($orderId);
-        $request->prefer('return=representation');
+        // capture the order at PayPal
+        $response = $client->getOrdersController()->captureOrder([
+            'id' => $orderId,
+            'prefer' => 'return=representation'
+        ]);
 
-        $response = $client->execute($request);
+        $order = $response->getResult();
 
-        if ($response->result->status === 'COMPLETED') {
+        if ($order->getStatus() === 'COMPLETED') {
             // order is paid
 
-            $order_nbr = htmlspecialchars($response->result->purchase_units[0]->reference_id);
+            $purchase_units = $order->getPurchaseUnits();
+            $order_nbr = htmlspecialchars($purchase_units[0]->getReferenceId());
 
             $return_str .= '<h1>'.$lang['label_payment_completed'].'</h1>';
             $return_str .= '<p>'.$lang['msg_payment_completed'].'</p>';
@@ -65,10 +72,10 @@ if(isset($_GET['token']) && $_REQUEST['query'] == $paypal_url_str){
 
         } else {
             $return_str .= "<h1>ERROR</h1>";
-            $return_str .= "<p>Status: " . htmlspecialchars($response->result->status) . "</p>";
+            $return_str .= "<p>Status: " . htmlspecialchars($order->getStatus()) . "</p>";
         }
 
-    } catch (HttpException $ex) {
+    } catch (ApiException $ex) {
         // error handling
         $return_str .= "<h1>ERROR</h1>";
         $return_str .= "<pre>" . htmlspecialchars($ex->getMessage()) . "</pre>";

--- a/plugins/se_paypal-pay/readme.md
+++ b/plugins/se_paypal-pay/readme.md
@@ -25,5 +25,5 @@ will be included after the checkout is done. A button for the PayPal payment pro
 
 ### Resources
 
-* https://github.com/paypal/Checkout-PHP-SDK
+* https://github.com/paypal/PayPal-PHP-Server-SDK
 * https://developer.paypal.com/


### PR DESCRIPTION
- Replaced deprecated `paypal-checkout-sdk` with `paypal-server-sdk` for updated features and improved SDK structure.
- Updated payment flow across plugins, replacing old client and order handling logic with the new SDK's `ClientBuilder` and `OrdersController`.
- Adjusted environment, authentication, and exception handling for compatibility with the new SDK.
- Updated `composer.lock` to reflect dependency changes, including related libraries (`apimatic/core`).
- Corrected `addon_name` typo in `writer.php` and updated outdated documentation in `readme.md`.