### PR TITLE
Confine order file paths and enforce order ownership

### DIFF
--- a/app/functions/functions.shop.php
+++ b/app/functions/functions.shop.php
@@ -1600,14 +1600,64 @@ function se_get_orders($user, $filter, $sort, $start=0, $limit=10) {
  */
  
 function se_get_order_details($id) {
-	
+
 	global $db_content;
 
 	$order = $db_content->get("se_orders","*", [
 		"id" => $id
 	]);
-	
+
 	return $order;
+}
+
+/**
+ * fetch an order by its number, but only if it belongs to $user_id.
+ * used to authorize order-related actions (downloads, uploads) and
+ * prevent IDOR via a guessed/forged order number.
+ *
+ * @param mixed $order_nbr the submitted order number
+ * @param int $user_id the logged-in customer
+ * @return array|null the order row, or null if not owned / not found
+ */
+function se_get_owned_order($order_nbr, $user_id) {
+
+	global $db_content;
+
+	$user_id = (int) $user_id;
+	if($user_id < 1 || !is_string($order_nbr) || $order_nbr === '') {
+		return null;
+	}
+
+	$order = $db_content->get("se_orders", "*", [
+		"order_nbr" => $order_nbr,
+		"user_id"   => $user_id
+	]);
+
+	return is_array($order) ? $order : null;
+}
+
+/**
+ * check whether a product (post_id) is part of the given order row.
+ *
+ * @param array $order an order row (must contain order_products JSON)
+ * @param int $product_id the product post_id
+ * @return bool
+ */
+function se_order_contains_product($order, $product_id) {
+
+	$product_id = (int) $product_id;
+	$items = json_decode($order['order_products'] ?? '', true);
+	if(!is_array($items)) {
+		return false;
+	}
+
+	foreach($items as $item) {
+		if((int) ($item['post_id'] ?? 0) === $product_id) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 /**

--- a/app/handlers/orders.php
+++ b/app/handlers/orders.php
@@ -13,23 +13,35 @@ if($order_page['page_permalink'] == '') {
 /* start purchased download */
 if(isset($_POST['dl_p_file']) OR isset($_POST['dl_p_file_ext'])) {
 	
-	if(is_numeric($_POST['dl_p_file'])) {
+	$product_id = 0;
+	$mode = '';
+	if(isset($_POST['dl_p_file']) && is_numeric($_POST['dl_p_file'])) {
 		$product_id = (int) $_POST['dl_p_file'];
 		$mode = 'internal_file';
 	}
-	if(is_numeric($_POST['dl_p_file_ext'])) {
-        $product_id = (int) $_POST['dl_p_file_ext'];
+	if(isset($_POST['dl_p_file_ext']) && is_numeric($_POST['dl_p_file_ext'])) {
+		$product_id = (int) $_POST['dl_p_file_ext'];
 		$mode = 'external_file_file';
+	}
+
+	// authorize: the customer must own a paid order that contains this product
+	$current_user_id = (int) ($_SESSION['user_id'] ?? 0);
+	$this_order = se_get_owned_order($_POST['order_id'] ?? '', $current_user_id);
+	if($product_id < 1
+		|| $this_order === null
+		|| $this_order['order_status_payment'] != '2'
+		|| !se_order_contains_product($this_order, $product_id)) {
+		http_response_code(403);
+		exit;
 	}
 	
 	$this_item = se_get_product_data($product_id);
 
 	if($mode == 'internal_file') {
-        $download_file = SE_PUBLIC.'/assets/files'.$this_item['file_attachment_as'];
-		$pathinfo = pathinfo($download_file);
-		$set_filename = $_POST['order_id'];
+		$download_file = se_resolve_within(SE_PUBLIC.'/assets/files', $this_item['file_attachment_as']);
+		$set_filename = basename($_POST['order_id']);
 
-		if(is_file($download_file)) {
+		if($download_file !== false && is_file($download_file)) {
 			header('Content-Description: File Transfer');
 			header('Content-Type: ' . mime_content_type($download_file));
 			header('Content-Disposition: attachment; filename="'.$set_filename.'"');
@@ -59,10 +71,21 @@ if(isset($_POST['dl_p_file']) OR isset($_POST['dl_p_file_ext'])) {
 
 if(isset($_POST['download_user_file'])) {
 
+    // authorize: the customer must own this order
+    if(se_get_owned_order($_POST['order'] ?? '', (int) ($_SESSION['user_id'] ?? 0)) === null) {
+        http_response_code(403);
+        exit;
+    }
+
     $target_dir = SE_CONTENT.'/uploads/';
-    $check_filename = $target_dir.$_POST['order'].'-'.$_POST['pos'].'-';
-    $checkfile = glob("$check_filename*");
-    if(is_array($checkfile) && $checkfile[0] != '') {
+    // confine the lookup prefix to the uploads directory (no traversal via order/pos)
+    $check_prefix = se_resolve_within($target_dir, $_POST['order'].'-'.$_POST['pos'].'-');
+    if($check_prefix === false) {
+        http_response_code(400);
+        exit;
+    }
+    $checkfile = glob($check_prefix.'*');
+    if(is_array($checkfile) && !empty($checkfile) && $checkfile[0] != '') {
 
         $download_file = $checkfile[0];
         $path_parts = pathinfo($download_file);
@@ -88,6 +111,12 @@ if(isset($_POST['download_user_file'])) {
  */
 if(isset($_POST['startUpload'])) {
 
+    // authorize: the customer must own this order
+    if(se_get_owned_order($_POST['order'] ?? '', (int) ($_SESSION['user_id'] ?? 0)) === null) {
+        http_response_code(403);
+        exit;
+    }
+
     $start_upload = true;
     $upload_status = '';
     $target_dir = SE_CONTENT.'/uploads/';
@@ -105,15 +134,24 @@ if(isset($_POST['startUpload'])) {
      * filename is order number + item position + time + extension
      */
 
-    $check_filename = $target_dir.$_POST['order'].'-'.$_POST['pos'].'-';
-    $checkfile = glob("$check_filename*");
-    if(is_array($checkfile) && $checkfile[0] != '') {
-        // there is already an upload for this, delete it first
-        unlink($checkfile[0]);
+    // confine the lookup prefix to the uploads directory (no traversal via order/pos)
+    $check_prefix = se_resolve_within($target_dir, $_POST['order'].'-'.$_POST['pos'].'-');
+    if($check_prefix === false) {
+        $start_upload = false;
+    } else {
+        $checkfile = glob($check_prefix.'*');
+        if(is_array($checkfile) && !empty($checkfile) && $checkfile[0] != '') {
+            // there is already an upload for this, delete it first
+            unlink($checkfile[0]);
+        }
     }
 
     $filename = $_POST['order'].'-'.$_POST['pos'].'-'.time().'.'.$extension;
-    $target_file = $target_dir.$filename;
+    // confine the upload target so order/pos cannot write outside the uploads dir
+    $target_file = se_resolve_within($target_dir, $filename);
+    if($target_file === false) {
+        $start_upload = false;
+    }
     if($start_upload == true) {
         if (move_uploaded_file($_FILES["upload_file"]["tmp_name"], $target_file)) {
             $upload_status = 'success';


### PR DESCRIPTION
Fixes path traversal and IDOR in the frontend orders handler:

- Route all order file paths (purchased downloads, customer upload download/storage) through se_resolve_within() so order/pos/DB values can no longer traverse outside their base directories.
- Add se_get_owned_order() / se_order_contains_product() and require the logged-in customer to own the order before any download or upload. Product downloads additionally require a paid order that actually contains the requested product.
- Harden the Content-Disposition filename via basename() and drop a dead pathinfo() call that would warn on a rejected path.