### PR TITLE
Add Smarty {plugin} block function for embedding plugins directly in …

### DIFF
--- a/app/functions/func_basics.php
+++ b/app/functions/func_basics.php
@@ -53,8 +53,41 @@ function buffer_script(string $script, ?string $parameters=NULL) {
 
 	$content = ob_get_clean();
 	$buffer = $parameter . $content;
-	
+
 	return $buffer;
+}
+
+
+/**
+ * Smarty {plugin} block - runs an installed plugin directly from a theme
+ * template, the same way [plugin=name]query[/plugin] does inside a content
+ * field (see text_parser()). Reuses buffer_script() so both entry points
+ * share identical behavior.
+ *
+ * Template usage:
+ *   {plugin name="former"}form_id=1{/plugin}
+ *
+ * @param array $params Smarty tag attributes, expects 'name'
+ * @param string|null $content block content (the query), null on the opening tag
+ * @param object $template Smarty template instance (unused, required by Smarty's block plugin signature)
+ * @param bool $repeat set by Smarty; unused here since we only act once, on the closing tag
+ * @return string
+ */
+
+function se_smarty_block_plugin($params, $content, $template, &$repeat) {
+
+	if(!isset($content)) {
+		return '';
+	}
+
+	$name = $params['name'] ?? '';
+	if($name === '') {
+		return '';
+	}
+
+	se_store_admin_helper('p', $name);
+
+	return buffer_script($name, $content);
 }
 
 

--- a/app/smarty.php
+++ b/app/smarty.php
@@ -12,6 +12,7 @@ $smarty->registerPlugin('modifier', 'htmlentities', 'htmlentities');
 $smarty->registerPlugin('modifier', 'strtolower', 'strtolower');
 $smarty->registerPlugin('modifier', 'trim', 'trim');
 $smarty->registerPlugin('function', 'img', 'se_smarty_function_img');
+$smarty->registerPlugin('block', 'plugin', 'se_smarty_block_plugin');
 
 $cache_id = md5($swifty_slug.$mod_slug);
 

--- a/docs/v2/de/09-01-00-themes.md
+++ b/docs/v2/de/09-01-00-themes.md
@@ -525,6 +525,39 @@ mitgelieferten Modifiern: `|htmlentities`, `|strtolower` und `|trim`. Besonders 
 relevant - Smartys 5 `DefaultExtension` enthält von Haus aus keinen `trim`-Modifier mehr, ohne
 diese manuelle Registrierung würde `{$var|trim}` in Deinen Templates also fehlschlagen.
 
+## Plugins direkt einbinden mit {plugin} {#plugins-direkt-einbinden-mit-plugin}
+
+`app/smarty.php` registriert außerdem `{plugin}` als Smarty-Block-Function
+(`se_smarty_block_plugin()` in `app/functions/func_basics.php`). Es ist das Template-Pendant zum
+`[plugin=name]query[/plugin]`-Shortcode, den Redakteure in Content-Feldern verwenden (siehe
+[Plugins → Wann werden welche Plugin-Dateien geladen?](09-02-plugins.md#wann-werden-welche-plugin-dateien-geladen))
+- beide Wege laufen intern über dieselbe `buffer_script()`-Funktion und verhalten sich deshalb
+identisch:
+
+```smarty
+{plugin name="example-plugin"}foo=bar{/plugin}
+```
+
+| Attribut | Pflicht | Bedeutung |
+|----------|---------|-----------|
+| `name`   | ja      | Verzeichnisname des Plugins unter `/plugins/`, genau wie beim `[plugin=...]`-Shortcode. |
+
+Der Block-Inhalt (`foo=bar` im Beispiel) entspricht der Query zwischen `[plugin=...]` und
+`[/plugin]` und wird genauso geparst (`parse_str()`) - jedes als `name=wert`-Paar übergebene Feld
+steht im Plugin als gleichnamige PHP-Variable zur Verfügung.
+
+Anders als der Content-Feld-Shortcode ist `{plugin}` ein regulärer Bestandteil des Templates und
+wird ganz normal von Smarty kompiliert - der Block-Inhalt darf deshalb auch Template-Variablen
+enthalten:
+
+```smarty
+{plugin name="example-plugin"}foo={$product.foo}{/plugin}
+```
+
+Nutze `{plugin}`, wenn Dein Theme einen Plugin-Aufruf fest ins Markup einbauen soll (z. B. immer
+ein bestimmtes Formular im Footer), ohne den Umweg über einen redaktionell gepflegten Snippet-
+oder Seiteninhalt.
+
 ## Responsive Bilder mit {img} {#responsive-bilder-mit-img}
 
 `app/smarty.php` registriert außerdem `{img}` als Smarty-Function (`app/functions/functions.img.php`).

--- a/docs/v2/de/09-02-plugins.md
+++ b/docs/v2/de/09-02-plugins.md
@@ -63,6 +63,8 @@ Folgende Includes sind möglich:
 ---
 
 1. Wenn ein Plugin über einen Shortcode eingebunden wird: `[plugin={plugin}]foo=bar[/plugin]`
+   - im Theme-Template gibt es dafür das Äquivalent `{plugin name="{plugin}"}foo=bar{/plugin}`,
+     siehe [Themes → Plugins direkt einbinden mit {plugin}](09-01-00-themes.md#plugins-direkt-einbinden-mit-plugin)
 2. Wenn ein Plugin innerhalb einer Seite eingebunden wird, also im Plugin-Tab aktiviert ist,
    wird der Seiteninhalt im Frontend durch das Plugin ersetzt.
 3. Wenn ein Plugin aktiv ist. Das bedeutet, es wurde entweder über den Plugin-Tab

--- a/docs/v2/en/09-01-00-themes.md
+++ b/docs/v2/en/09-01-00-themes.md
@@ -494,6 +494,39 @@ Smarty ships by default: `|htmlentities`, `|strtolower` and `|trim`. The `trim` 
 particular - Smarty 5's `DefaultExtension` no longer includes a `trim` modifier out of the box,
 so without this manual registration `{$var|trim}` would fail in your templates.
 
+## Embedding plugins directly with {plugin} {#embedding-plugins-directly-with-plugin}
+
+`app/smarty.php` also registers `{plugin}` as a Smarty block function
+(`se_smarty_block_plugin()` in `app/functions/func_basics.php`). It's the template counterpart to
+the `[plugin=name]query[/plugin]` shortcode editors use in content fields (see
+[Plugins → When are which plugin files loaded?](09-02-plugins.md#when-are-which-plugin-files-loaded))
+- both paths run through the same `buffer_script()` function internally, so they behave
+identically:
+
+```smarty
+{plugin name="example-plugin"}foo=bar{/plugin}
+```
+
+| Attribute | Required | Meaning |
+|-----------|----------|---------|
+| `name`    | yes      | Directory name of the plugin under `/plugins/`, same as with the `[plugin=...]` shortcode. |
+
+The block content (`foo=bar` in the example) corresponds to the query between `[plugin=...]`
+and `[/plugin]` and is parsed the same way (`parse_str()`) - every `name=value` pair you pass is
+available inside the plugin as a PHP variable of the same name.
+
+Unlike the content-field shortcode, `{plugin}` is a regular part of the template and gets
+compiled by Smarty like anything else - so the block content may also contain template
+variables:
+
+```smarty
+{plugin name="example-plugin"}foo={$product.foo}{/plugin}
+```
+
+Use `{plugin}` when your theme wants to hard-wire a plugin call into its markup (e.g. always
+showing a particular form in the footer) without going through an editor-managed snippet or page
+content.
+
 ## Responsive images with {img} {#responsive-images-with-img}
 
 `app/smarty.php` also registers `{img}` as a Smarty function (`app/functions/functions.img.php`).

--- a/docs/v2/en/09-02-plugins.md
+++ b/docs/v2/en/09-02-plugins.md
@@ -63,6 +63,8 @@ The following includes are possible:
 ---
 
 1. When a plugin is integrated via shortcode: `[plugin={plugin}]foo=bar[/plugin]`
+   - the theme-template equivalent is `{plugin name="{plugin}"}foo=bar{/plugin}`, see
+     [Themes → Embedding plugins directly with {plugin}](09-01-00-themes.md#embedding-plugins-directly-with-plugin)
 2. When a plugin is integrated within a page, i.e., activated in the plugin tab,
    the page content is replaced by the plugin in the frontend.
 3. When a plugin is active. This means that it has either been integrated into a page via the plugin tab


### PR DESCRIPTION
…templates

Implement `se_smarty_block_plugin()` as template equivalent to `[plugin=name]query[/plugin]` shortcode. Both entry points share identical behavior via `buffer_script()`. Block content supports template variables and is parsed the same way as shortcode query strings. Register block function in `app/smarty.php` and document usage in theme and plugin documentation (de/en).